### PR TITLE
force sqlite3 to be dependency-free by compiling from scratch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,7 @@ name = "libsqlite3-sys"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1058,6 +1059,7 @@ dependencies = [
  "juniper 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper_codegen 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper_iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 base64 = "0.10.0"
 bytes = "0.4.12"
+libsqlite3-sys = { version = ">=0.8.0, <0.13.0", features = ["bundled"] }
 diesel = { version = "1.4.1", features = ["sqlite"] }
 diesel_migrations = "1.4.0"
 dotenv = "0.9.0"


### PR DESCRIPTION
until diesel exports this as a feature I propose to force cargo into this by hand. 
this allows the project to be built on machines with old sqlite3 versions. In my case, that is Ubuntu 16.04.